### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Virtual FAT32 disk
   ~~~
   git clone git@github.com:Travelinglight/VHD.git
   ~~~
-2. Use Windows to generate a .vhd file.
+2. use Windows to generate a .vhd file.
   * the format should be FunAT32
-  * the filesize should not be too large, 20MB is recommended
+  * the file size should not be too large. 20MB is recommended
   * the number of bytes per block is recommended to be 512
   * put the .vhd file into the repo
 
@@ -31,22 +31,22 @@ Virtual FAT32 disk
   ~~~
   type "help" for instructions list
   
-## Things you can do
-1. list out the file list, with detailed infomation
+## Things You Can Do
+1. list the files, with detailed information
 2. remove a file from the VHD
 3. copy a file from the VHD to the outside
-4. move a file from outside into the VHD
+4. move a file from the outside into the VHD
 
 ## Variables Specification
-1. FILE* fp ---- file point for .vhd file
+1. FILE* fp ---- file pointer for .vhd file
 2. word offSet ---- to describe the offset of fp
-3. byte buff_block[32768] ---- the buff of a block
-4. byte buff_byte ---- the buff of a byte
-5. hWord FAT[32768] ---- the FAT store in memory
+3. byte buff_block[32768] ---- the buffer of a block
+4. byte buff_byte ---- the buffer of a byte
+5. hWord FAT[32768] ---- the FAT stored in memory
 6. hWord nByte ---- the number of bytes within a block
 7. hWord nBlock ---- the number of blocks within a cluster
-8. hWord nCluster ---- the number of clusters in data area of the vhd
-9. hWord nFAT ---- the number of FATs in the vhd
+8. hWord nCluster ---- the number of clusters in data area of the VHD
+9. hWord nFAT ---- the number of FATs in the VHD
 10. hWord nBFAT ---- the number of blocks within a FAT
 11. hWord nFile ---- the maximum number of files that could be recorded in the root directory
 12. file* fIndex[512] ---- the file index maintained in memory, corresponding to the root directory
@@ -54,63 +54,63 @@ Virtual FAT32 disk
 ## Functions Specification
 ### Important functions
 1. <b>init</b>
-  1. read parameters from boot block
-  2. read the whole FAT
-  3. read root directory and initialize the fIndex array
-2. <b>ls: list file infomation</b>
-  1. list the file id, file name, attribute, timestamp, and file size for each file in the fIndex
-3. <b>cp: copy a file from vhd to outside</b>
-  1. generate the filename of the outside file, and open it
-  2. read data area according to the FAT, write the destination file block by block
+    1. read parameters from boot block
+    2. read the whole FAT
+    3. read root directory and initialize the fIndex array
+2. <b>ls: list file information</b>
+    1. list the file id, file name, attribute, timestamp, and file size of each file in the fIndex
+3. <b>cp: copy a file from vhd to the outside</b>
+    1. generate the file name of the outside file, and open it
+    2. read data area according to the FAT, and write the destination file block by block
 4. <b>rm: remove a file from VHD</b>
-  1. clear the FAT chain (reset those half_word in FAT describing the clusters of the file to 0)
-  2. put 0xE5 to the first byte of the filename in root directory
-  3. free and clear the file struct in the fIndex array
-5. <b>mv: move a file from outside into the VHD</b>
-  1. parse the filename and file_extention
-  2. get the file size
-  3. find and clear enough clusters that are not used, and record them in an array
-  4. obtain other necessary attributes describing a file
-  5. modify root directory with the attributes obtained before
-  6. modify FAT according to the clusters array found out before
-  7. read binary data from source file, and write them into the clusters found before, byte by byte
+    1. clear the FAT chain (reset those half_word in FAT describing the clusters of the file to 0)
+    2. put 0xE5 to the first byte of the file name in the root directory
+    3. free and clear the file struct in the fIndex array
+5. <b>mv: move a file from the outside into the VHD</b>
+    1. parse the file name and file_extention
+    2. get the file size
+    3. find and clear enough clusters that are not used, and record them in an array
+    4. obtain the other necessary attributes describing a file
+    5. modify the root directory with the attributes obtained before
+    6. modify FAT according to the clusters array found out before
+    7. read binary data from the source file, and write them into the clusters found before, byte by byte
 
 ### Complementary functions
 1. readBlock: to read a block from .vhd file into buff_block
 2. readByte: to read and return a byte from .vhd file
 3. readHWord: to read and return a half_word from .vhd file. This function calls:
-  1. readByte;
+    * readByte;
 4. readWord: to read and return a word from .vhd file. This function calls:
-  1. readHWord;
+    * readHWord;
 5. readFAT: to read the while FAT from .vhd file into FAT
 6. raedFileName: to read the filename from .vhd file, format it and handle special cases. This function calls:
-  1. readByte;
+    * readByte;
 7. readFileExt: to read the file extention from .vhd file and format it. This function calls:
-  1. readByte;
+    * readByte;
 8. readAttr: to read the attribute of a file from .vhd file. This function calls:
-  * readByte;
+    * readByte;
 9. readFileTimeStamp: to read the time and date of the file from root directory in .vhd file. This function calls:
-  * readHWord;
+    * readHWord;
 10. readFileStart: to read the id of start cluster of the file from .vhd file. This function calls:
-  * readHWord;
+    * readHWord;
 11. readFileSize: to read the file size from the root directory in .vhd file. This function calls:
-  * readHWord;
+    * readHWord;
 12. readRD: to read the info of all files. This function calls:
-  1. readFileExt;
-  2. readFileAttr;
-  3. readFileTimeStamp;
-  4. readFileStart;
-  5. readFileSize;
-13. printFileName: to print the filename in normal way
+    * readFileExt;
+    * readFileAttr;
+    * readFileTimeStamp;
+    * readFileStart;
+    * readFileSize;
+13. printFileName: to print the file name in normal way
 14. printFileAttr: to print the file attribute in binary format
 15. printFileTime: to print the time of the file vividly
-16. printFileSize: to print the file size in Bytes
-17. cpCluster: to copy a whole cluster to destination field, which is called by function cp;
-18. cvt2upper: to convert a string (e.g. filename) to uppercase string
-19. getTime: to get the current time and transform it and store it in a struct
+16. printFileSize: to print the file size in bytes
+17. cpCluster: to copy a whole cluster to a destination field, which is called by function cp;
+18. cvt2upper: to convert a string (e.g. filename) to an uppercase string
+19. getTime: to get the current time, transform it and store it in a struct
 20. writeTime: to write the time and date into the root directory in .vhd file
 
-## Bugs exist
+## Bugs Exist
 1. After a .txt file is written into .vhd file, there would be an extra half_word (0x0AFF) appended to the original file.
-2. The file of 2 bytes would become 512 bytes after being written into and extracted out from VHD.
+2. The file of 2 bytes would become 512 bytes after being written into and extracted from VHD.
 3. Some constants are used in the program, so the program may not be universal to all FAT32 VHDs.


### PR DESCRIPTION
- The capitalization rule is not consistent among the sub-headings
- Names are not consistent, e.g., file name & filename, file size & filesize, vdh & VDH
- Typo: "infomation" -> "information"
- Some article issues: missing "a" or "the"
- Some inappropriate abbreviation: "buff" -> "buffer", "point" -> "pointer"
- The nested numbered list is not correctly displayed
- Minor punctuation issues

Fix #3 
